### PR TITLE
Implement delete task by id functionality

### DIFF
--- a/TaskManager.API/Function.cs
+++ b/TaskManager.API/Function.cs
@@ -45,6 +45,7 @@ public class Function
             ("GET", { }) => await GetTaskById(taskId),
             ("POST", null) => await CreateTask(request),
             ("PUT", { }) => await UpdateTask(request),
+            ("DELETE", { }) => await DeleteTask(request),
             _ => new APIGatewayProxyResponse { StatusCode = (int)HttpStatusCode.MethodNotAllowed, Body = "{\"message\":\"Method not allowed.\"}" },
         };
     }
@@ -164,5 +165,27 @@ public class Function
                 Body = "{\"message\":\"Invalid request body.\"}"
             };
         }
+    }
+    private async Task<APIGatewayProxyResponse> DeleteTask(APIGatewayProxyRequest request)
+    {
+        var taskId = request.PathParameters["id"];
+        var taskToDelete = await _context.LoadAsync<TaskItem>(taskId);
+
+        if (taskToDelete == null)
+        {
+            return new APIGatewayProxyResponse
+            {
+                StatusCode = (int)HttpStatusCode.NotFound,
+                Body = "{\"message\":\"Task not found.\"}"
+            };
+        }
+
+        await _context.DeleteAsync(taskToDelete);
+
+        return new APIGatewayProxyResponse
+        {
+            StatusCode = (int)HttpStatusCode.NoContent,
+            Body = ""
+        };
     }
 }


### PR DESCRIPTION
### PR Description: Feature/Add DELETE Task by ID Endpoint
**Summary:**
This pull request adds support for deleting a single task by its unique ID. The DELETE /tasks/{id} endpoint has been implemented in the Lambda function, allowing users to delete a task. A unit test has also been added to verify this new functionality.

### AWS Console Changes:
API Gateway: A PUT method was added to the /tasks/{id} resource and configured to use Lambda Proxy Integration. The API was then redeployed to the prod stage.

Testing evidence:

Add new task using the POST /tasks endpoint: 
<img width="2222" height="1120" alt="image" src="https://github.com/user-attachments/assets/4d6ea569-914a-42bc-9009-ec5da747a788" />

View the task using the GET /tasks endpoint:
<img width="2220" height="1332" alt="image" src="https://github.com/user-attachments/assets/ed7e397f-a5d6-4ad0-beca-499c5357788f" />

DELETE the task using the DELETE /tasks/{id} endpoint: 
<img width="2236" height="1016" alt="image" src="https://github.com/user-attachments/assets/c0ee01df-4d13-41f5-b704-13c0b3a15080" />

Check the task has been deleted calling the GET /tasks endpoint again: 
<img width="2228" height="1258" alt="image" src="https://github.com/user-attachments/assets/6d8349b5-1a18-4129-9c73-e459cd15232d" />
